### PR TITLE
streamlining and fixing clean

### DIFF
--- a/bin/proddsalloc
+++ b/bin/proddsalloc
@@ -1,6 +1,8 @@
 #!/bin/sh
 #set -x
 
+
+
 out=$(whence zbrewfuncs >/dev/null)
 if [ $? -eq 0 ]; then
 	. zbrewfuncs
@@ -9,8 +11,38 @@ else
 	exit 4
 fi
 
+InvalidOption=1
+TooFewParms=2
+UnknownAction=3
+PrefixTooLong=4
+
+#
+# Temporary hack - replace with a proper message file
+#
+msg() {
+        pgm=$1
+        msgnum=$2
+        msgtype=$3
+
+        shift 3
+        args=$*
+
+        case ${msgnum} in
+                ${InvalidOption}) msgtext="Invalid option specified: -";;
+                ${TooFewParms}) msgtext="Too few Parameters specified. Expected 2 but received: ";;
+                ${UnknownAction}) msgtext="Unknown action specified: ";;
+                ${PrefixTooLong}) msgtext="Prefix must be 6 characters or less. Received: ";;
+                *) msgtext="Internal Error. Unknow msgnum: ${msgnum}";;
+        esac
+        echo "ZCL000"${msgnum}${msgtype} "${msgtext}${args}" >&2
+}
+
+delds() {
+        echo "$1" | awk '{ ds=$1; $1=""; if ($ds != "") { rc=system("drm -f " ds); if (rc > 0) { exit(rc); } } }'
+        exit $?
+}
+
 crtds() {
-	echo $1
 	echo "$1" | awk '{ ds=$1; $1=""; attrs=$0; if ($ds != "") { rc=system("dtouch " attrs " " ds); if (rc > 0) { exit(rc); } } }'
 	exit $?
 }
@@ -58,11 +90,40 @@ zzz
 	exit 0
 }
 
+while getopts ":vdc" opt; do
+  case ${opt} in
+    c )
+      clean=1
+      ;;
+    d )
+      debug=1
+      ;;
+    v )
+      verbose=1
+      opts="-v"
+      ;;
+    \?)
+      if [ ${OPTARG} != "?" ]; then
+        msg smpconfig ${InvalidOption} E "${OPTARG}"
+      fi
+      syntax
+      exit 4
+      ;;
+  esac
+done
+shift $(expr $OPTIND - 1 )
+if [ $# -lt 1 ]; then
+        msg smpconfig ${TooFewParms} E "$#"
+        syntax
+        exit 16
+fi
+
 mydir=$(callerdir ${0})
-prefix=$1
-ussname=$2
-shift 2
-opts=$*
+
+sw=$1
+ussname=$(echo ${sw} | tr '[:upper:]' '[:lower:]');
+zosname=$(echo ${sw} | tr '[:lower:]' '[:upper:]');
+prefix=`echo "${ussname}" | awk '{ print substr($1, 0, 3) }'`
 
 props="${mydir}/../../zbrew/properties/zbrewprops.json"
 zbrewpropse zbrew config "${props}"
@@ -82,6 +143,15 @@ fi
 # Obtain list of all Target and Distribution Datasets to allocate, exclude ZFS
 ds=`echo "${libs}" | awk -v pfx="${ZBREW_HLQ}${ussname}." '($2 != "ZFS") {print pfx$1" -t"$2" -r"$3" -l"$4" -s"$5*56"K"}'`
 
+if [ "${clean}" = "1" ]; then
+	out=`delds "${ds}"`
+	rc=$?
+	if [ $rc -gt 0 ]; then
+        	echo "Dataset cleanup failed. Installation aborted"
+        	exit $rc
+	fi
+fi
+
 out=`crtds "${ds}"`
 rc=$?
 if [ $rc -gt 0 ]; then
@@ -90,8 +160,21 @@ if [ $rc -gt 0 ]; then
 fi
 
 # Obtain list of ZFS and allocate/mount
+dsnl=`echo "${libs}" | awk -v pfx="${ZBREW_HLQ}${ussname}." '($2 == "ZFS") {print pfx""$1" "$3" "$4" "$7","}'`
 ds=`echo "${libs}" | awk -v pfx="${ZBREW_HLQ}${ussname}." '($2 == "ZFS") {print pfx""$1" "$3" "$4" "$7","}' | tr -d "\n"`
 zfscnt=`echo "${ds}" | awk -F, '{}END {print NF}'`
+
+if [ "${clean}" = "1" ]; then
+	/usr/sbin/unmount -R ${ZFSROOT}${ZFSDIR}
+	out=`delds "${dsnl}"`
+        rc=$?
+        if [ $rc -gt 0 ]; then
+                echo "ZFS cleanup failed. Installation aborted"
+                exit $rc
+        fi
+
+fi
+
 cntr=1
 while [ $cntr -le $zfscnt ];  
 do

--- a/bin/smp
+++ b/bin/smp
@@ -137,6 +137,11 @@ if [ ${verbose} -gt 0 ]; then
 fi
 mvscmdauth ${opts} --pgm=gimsmp --smpcsi=${SMPCSI} --smpwkdir=${SMPWKDIR} --smplog=${SMPLOG} --smprpt=${SMPRPT} --smplist=${SMPLIST} --smpnts=${SMPNTS} --client=${SMPCLIENT} --server=${SMPSERVER} --sysprint=${SYSPRINT} --smpout=stdout --smpcntl=stdin
 rc=$?
+if [ ${rc} = 0 ]; then
+	unlink "${SMPRPT}" 2>/dev/null
+	unlink "${SYSPRINT}" 2>/dev/null
+	unlink "${SMPLOG}" 2>/dev/null
+fi
 if [ ${verbose} -gt 0 ]; then
 	end=`date +%H:%M:%S`
 	echo "${end} gimsmp finished" >&2

--- a/bin/smpappacc
+++ b/bin/smpappacc
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+#set -x
 . zbrewfuncs
 InvalidOption=1
 TooFewParms=2
@@ -39,12 +39,77 @@ Examples:
 	exit 16
 }
 
+
+fmids() {
+        zbrewlog "fmids" $*
+        sw=$1
+        smplist="${ZBREW_TMP}/smpfmid.$$.smplist"
+        smpout=`smp -i "${ZBREW_HLQ}${sw}G.GLOBAL.CSI" -l "${smplist}" <<zzz
+  SET BDY(GLOBAL).
+  LIST FUNCTIONS.
+zzz`
+        rc=$?
+        zbrewlog "fmids RC: ${rc}"
+        if [ $rc -eq 0 ]; then
+                fmids=`awk ' /= FUNCTION/ { print $1; }' ${smplist}`
+                uniq_fmids=`echo ${fmids} | tr ' ' '\n' | sort | uniq`
+                echo ${uniq_fmids}
+
+        else
+                echo "smpfmid failed with rc:$rc" >&2
+                echo "${smpout}" >&2
+        fi
+        rm -f "${smplist}"
+        return $rc
+}
+
+fmidset() {
+        zbrewlog "fmidset" $*
+        sw=$1
+        shift
+        fmids=$*
+        fmidset="${sw}FS"
+
+        tmpCntlHFS="${ZBREW_TMP}/smpfmid.$$.smpcntl"
+        echo "  SET BDY(GLOBAL)." >>${tmpCntlHFS}
+        echo "  UCLIN." >>${tmpCntlHFS}
+        echo "  REP FMIDSET(${fmidset})" >>${tmpCntlHFS}
+        echo "  FMID(" >>${tmpCntlHFS}
+        for fmid in $fmids; do
+                echo "    ${fmid}" >>${tmpCntlHFS}
+        done
+        echo "  )." >>${tmpCntlHFS}
+        echo "  ENDUCL." >>${tmpCntlHFS}
+        smpout=`smp -i "${ZBREW_HLQ}${sw}G.GLOBAL.CSI" <${tmpCntlHFS}`
+        rc=$?
+        zbrewlog "fmidset RC: ${rc}"
+        rm ${tmpCntlHFS}
+        if [ $rc -gt 4 ] || [ $verbose -gt 0 ]; then
+                echo "fmidset ended with return code: $rc" >&2
+                echo "${smpout}" >&2
+        fi
+        echo "${fmidset}"
+        return $rc
+}
+
+
+
 runapply() {
+	sw="$1"
+
+        fmids=`fmids ${sw}`
+        if [ $? -gt 0 ]; then
+                return $?
+        fi
+
+        fmidset=`fmidset ${sw} ${fmids}`
+        if [ $? -gt 4 ]; then
+                return $?
+        fi
+        if [ ${verbose} -gt 0 ]; then
+                echo "Running ${smpfunc} ${check} ${sw} ${fmidset}" >&2
+        fi
 	
-	smpfunc="$1"
-	check="$2"
-	sw="$3"
-	fmids="$4"
 	tmpCntlHFS=${ZBREW_TMP}/$$.${check}.cntl.xml
 
 	if [ "${smpfunc}" = "APPLY" ]; then
@@ -76,9 +141,10 @@ runapply() {
 	
 	smpout=`smp -w ${ZBREW_TMP} -r "${smprpt}" -p "${smpsysprint}" -i ${ZBREW_HLQ}${sw}G.GLOBAL.CSI <${tmpCntlHFS}`
 	rc=$?
+	zbrewlog "${smpfunc} ${check} ${sw} Return Code: ${rc}"
 	rm "${tmpCntlHFS}"
 	if [ $rc -gt 0 ] || [ $verbose -gt 0 ]; then
-		echo "${smpout}"
+		echo "${smpout}" >&2 
 	else
 		rm "${smprpt}"
 		rm "${smpsysprint}"
@@ -87,32 +153,28 @@ runapply() {
         return ${rc}
 } 
 
-apply() {
-	sw=$3
-	
-	if [ ${check} = "CHECK" ]; then
-		appmsg="${smpfunc}(CHECK)"
-	else
-		appmsg="${smpfunc}"
-	fi
-	if [ "${verbose}" -gt '0' ]; then
-                echo "Running SMPE ${appmsg} for ${sw}"
-        fi
-	out=`runapply $*`
-	rc=$?
-	if [ ${rc} -gt 0 ] || [ ${verbose} -gt 0 ]; then
- 		echo "SMP/E ${appmsg} of ${sw} returned code ${rc}. ${out}" >&2
-		return ${rc}
-	fi
-
-        return ${rc}
-}
 
 debug=0
 verbose=0
 opts=""
-while getopts ":vd" opt; do
+while getopts ":vdcpqrs" opt; do
   case ${opt} in
+    p )
+      smpfunc="APPLY"
+      check="CHECK"
+      ;;
+    q ) 
+      smpfunc="APPLY"
+      check="NOCHECK"
+      ;;
+    r )
+      smpfunc="ACCEPT"
+      check="CHECK"
+      ;;
+    s )
+      smpfunc="ACCEPT"
+      check="NOCHECK"
+      ;;
     d )
       debug=1
       opts="${opts} -d"
@@ -131,7 +193,7 @@ while getopts ":vd" opt; do
   esac
 done
 shift $(expr $OPTIND - 1 )
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
 	msg zbrew ${TooFewParms} E "$#"
 	syntax
 	exit 16
@@ -141,12 +203,10 @@ mydir=$(callerdir ${0})
 props="${mydir}/../properties/zbrewprops.json"
 zbrewpropse zbrew config "${props}"
 
-smpfunc=$(echo ${1} | tr '[:lower:]' '[:upper:]')
-check=$(echo ${2} | tr '[:lower:]' '[:upper:]') 
-zosname=$(echo ${3} | tr '[:lower:]' '[:upper:]') 
-fmids="$4"
+zosname=$(echo ${1} | tr '[:lower:]' '[:upper:]') 
+fmids="$2"
 
-out=`apply ${smpfunc} ${check} ${zosname} ${fmids}`; 
+out=`runapply ${zosname}`; 
 
 rc=$? 
 if [ $rc -gt 0 ]; then

--- a/bin/smpconfig
+++ b/bin/smpconfig
@@ -310,8 +310,12 @@ fi
 mydir=$(callerdir ${0})
 props="${mydir}/../properties/zbrewprops.json"
 zbrewpropse zbrew config "${props}"
+sw=$1
+ussname=$(echo ${sw} | tr '[:upper:]' '[:lower:]');
+zosname=$(echo ${sw} | tr '[:lower:]' '[:upper:]');
+prefix=`echo "${ussname}" | awk '{ print substr($1, 0, 3) }'`
 
-PFX=$(echo ${1} | tr '[:lower:]' '[:upper:]');
+PFX=$(echo ${sw} | tr '[:lower:]' '[:upper:]');
 HLQ="${ZBREW_HLQ}"
 
 if [ ${#PFX} -gt 6 ]; then

--- a/bin/smpcrdddef
+++ b/bin/smpcrdddef
@@ -9,6 +9,33 @@ else
 	exit 4
 fi
 
+InvalidOption=1
+TooFewParms=2
+UnknownAction=3
+PrefixTooLong=4
+
+#
+# Temporary hack - replace with a proper message file
+#
+msg() {
+        pgm=$1
+        msgnum=$2
+        msgtype=$3
+
+        shift 3
+        args=$*
+
+        case ${msgnum} in
+                ${InvalidOption}) msgtext="Invalid option specified: -";;
+                ${TooFewParms}) msgtext="Too few Parameters specified. Expected 2 but received: ";;
+                ${UnknownAction}) msgtext="Unknown action specified: ";;
+                ${PrefixTooLong}) msgtext="Prefix must be 6 characters or less. Received: ";;
+                *) msgtext="Internal Error. Unknow msgnum: ${msgnum}";;
+        esac
+        echo "ZCL000"${msgnum}${msgtype} "${msgtext}${args}" >&2
+}
+
+
 
 #for All but ZFS libraries
 targ_dddefs(){
@@ -88,12 +115,40 @@ zzz
 
 }
 
+while getopts ":vdc" opt; do
+  case ${opt} in
+    c )
+      clean=1
+      ;;
+    d )
+      debug=1
+      ;;
+    v )
+      verbose=1
+      opts="-v"
+      ;;
+    \?)
+      if [ ${OPTARG} != "?" ]; then
+        msg smpconfig ${InvalidOption} E "${OPTARG}"
+      fi
+      syntax
+      exit 4
+      ;;
+  esac
+done
+shift $(expr $OPTIND - 1 )
+if [ $# -lt 1 ]; then
+        msg smpconfig ${TooFewParms} E "$#"
+        syntax
+        exit 16
+fi
 
 mydir=$(callerdir ${0})
-prefix=$1
-zosname=$2
-shift 2
-opts=$*
+
+sw=$1
+ussname=$(echo ${sw} | tr '[:upper:]' '[:lower:]');
+zosname=$(echo ${sw} | tr '[:lower:]' '[:upper:]');
+prefix=`echo "${ussname}" | awk '{ print substr($1, 0, 3) }'`
 
 props="${mydir}/../../zbrew/properties/zbrewprops.json"
 zbrewpropse zbrew config "${props}"
@@ -101,12 +156,11 @@ zbrewpropse zbrew config "${props}"
 props=$(callerdir "$0")"/../../zbrew/properties/globalprops.json"
 zbrewpropse zbrew global ${props}
 
-props="${mydir}/../../zbrew-${prefix}/${zosname}/${zosname}install.json"
+props="${mydir}/../../zbrew-${prefix}/${ussname}/${ussname}install.json"
 zbrewpropse "${zosname}" install "${props}"
 
-smpelibs="${mydir}/../../zbrew-${prefix}/${zosname}/${zosname}bom.json"
+smpelibs="${mydir}/../../zbrew-${prefix}/${ussname}/${ussname}bom.json"
 
-zosname=$(echo ${zosname} | tr '[:lower:]' '[:upper:]')
 
 # Update Target Zone DDDEFS, note Target Zone contains both Targ/Dist libraries
 smpuclin="  SET   BDY(${zosname}T).

--- a/bin/smpfromnts
+++ b/bin/smpfromnts
@@ -40,7 +40,6 @@ receivefromnts() {
 	sw="$1"
 	NTS="$2"
 	order=`ls $NTS`
-	echo ${order}
 	if [ $? -gt 0 ]; then
 		echo "Unable to list contents of NTS file ${NTS}" >&2
 		exit 16
@@ -83,8 +82,12 @@ zbrewpropse zbrew config "${props}"
 debug=0
 verbose=0
 opts=""
-while getopts ":vd" opt; do
+while getopts ":vdc" opt; do
   case ${opt} in
+    c )
+      clean=1
+      opts="${opts} -c"
+      ;;
     d )
       debug=1
       opts="${opts} -d"
@@ -103,19 +106,40 @@ while getopts ":vd" opt; do
   esac
 done
 shift $(expr $OPTIND - 1 )
-if [ $# -lt 2 ]; then
+if [ $# -lt 1 ]; then
 	msg smpfromnts ${TooFewParms} E "$#"
 	syntax
 	exit 16
 fi
+sw=$1
+zosname=$(echo ${sw} | tr '[:lower:]' '[:upper:]');
+ussname=$(echo ${sw} | tr '[:upper:]' '[:lower:]');
+prefix=`echo "${zosname}" | awk '{ print substr($1, 0, 3) }'`
+lprefix=`echo "${ussname}" | awk '{ print substr($1, 0, 3) }'`
+NTS="${ZBREW_TMP}/smpnts.${zosname}"
 
-zosname=$(echo ${1} | tr '[:lower:]' '[:upper:]'); 
-ntsdir=$2
+if [ "$prefix" = "ZHW" ]; then
+	order='order1'
+        mkdir -p "${NTS}/${order}"
+        prodpkg="${mydir}/../../zbrew-${lprefix}/${ussname}/${ussname}crtpkg"
+        if [ -f "${prodpkg}" ]; then
+                ${prodpkg} ${NTS}/${order}
+                rc=$?
+        else
+                echo "Unable to find product packaging program: ${prodpkg}. Installation failed."
+                return 16
+        fi
+fi
 
-out=`receivefromnts ${zosname} ${ntsdir}`; 
+
+out=`receivefromnts ${zosname} ${NTS}`; 
 rc=$? 
 if [ $rc -gt 0 ]; then
 	echo "SMP/E RECEIVE FROMNTS failed with return code $rc" >&2
+else
+	if [ "$prefix" = "ZHW" ]; then
+		rm -rf /$ZBREW_TMP/smpnts.ZHW110 2>/dev/null
+	fi
 fi
 
 exit $rc

--- a/bin/smpfromshopz
+++ b/bin/smpfromshopz
@@ -102,8 +102,12 @@ zbrewpropse zbrew config "${props}"
 debug=0
 verbose=0
 opts=""
-while getopts ":vd" opt; do
+while getopts ":vdc" opt; do
   case ${opt} in
+    c )
+      clean=1
+      opts="${opts} -c"
+      ;; 
     d )
       debug=1
       opts="${opts} -d"

--- a/bin/zbrew
+++ b/bin/zbrew
@@ -80,6 +80,7 @@ search() {
 }
 
 #
+opts=$*
 # Temporary hack - replace with proper RESTful call to ShopZ to submit request
 # Response will be an ORDER number that, when complete, will have information needed  
 # for the RECEIVE
@@ -103,76 +104,24 @@ uninstall() {
 	return 4
 }
 
-receiveshopz() {
-	zbrewlog "smpfromshopz" $*
-	sw=$1
-	shift
-	opts=$*
-	NTS=`smpfromshopz ${sw}`
-	rc=$?
-	if [ $rc -gt 0 ]; then
-		return $rc
-	fi
-	zbrewlog "smpfromshopz RC: ${rc}"
-	return $?
-}
 
-receiveppa() {
-	zbrewlog "receiveppa" $*
-
-	rc=$?
-	zbrewlog "receiveppa RC: ${rc}"
-}
-
-receivelocal() {
-	zbrewlog "smpfromnts" $*
-	sw=$1
-	zosname=$(echo ${sw} | tr '[:lower:]' '[:upper:]');
-	ussname=$(echo ${sw} | tr '[:upper:]' '[:lower:]');
-	prefix=`echo "${zosname}" | awk '{ print substr($1, 0, 3) }'`
-	lprefix=`echo "${ussname}" | awk '{ print substr($1, 0, 3) }'`
-	NTS="${ZBREW_TMP}/smpnts.${zosname}"
-
-	if [ "$prefix" = "ZHW" ]; then	
-		order='order1'
-		mkdir -p "${NTS}/${order}"
-      		prodpkg="${mydir}/../../zbrew-${lprefix}/${ussname}/${ussname}crtpkg"
-		if [ -f "${prodpkg}" ]; then
-	        	${prodpkg} ${NTS}/${order}
-	        	rc=$?
-		else
-	        	echo "Unable to find product packaging program: ${prodpkg}. Installation failed."
-			return 16
-		fi
-	fi
-	if [ $rc -gt 0 ]; then
-		return $rc;
-	fi	
-	`smpfromnts ${sw} ${NTS} ${opts}`
-	rc=$?
-	zbrewlog "smpfromnts RC: ${rc}"
-	if [ $rc -gt 0 ]; then
-		return $rc;
-	fi
-	if [ "$prefix" = "ZHW" ]; then
-		rm -rf "${NTS}"
-	fi	
-	return
-}
 
 receive() {
 	if [ ${verbose} -gt 0 ]; then
-		echo "receive $*" >&2
+		echo "Performing SMP/E Receive $*" >&2
 	fi
 	case ${SMPE_DELIVERY} in
 		SHOPZ)
-			out=`receiveshopz $*`
+			zbrewlog "Receiving from ShopZ for: "${sw}
+			out=`smpfromshopz ${opts} ${sw}`
 			;;
 		PPA)
-			out=`receiveppa $*`
+			zbrewlog "Receiving from PPA for: "${sw}
+			out=`smpfromppa ${opts} ${sw}`
 			;;
 		LOCAL)
-			out=`receivelocal $*`
+			zbrewlog "Receiving from LOCAL NTS for: "${sw}
+			out=`smpfromnts ${opts} ${sw}`
 			;;
 		*)
 			echo "SMPE_DELIVERY must be one of SHOPZ, PPA, LOCAL and must be specified in your ORDER file" >&2
@@ -186,9 +135,6 @@ receive() {
 #
 prodprereq() {
 	zbrewlog "prodprereq" $*
-	sw=$1
-	shift 1
-	opts=$*
 	tmp_frspace=$(df -k ${ZBREW_TMP} | tail -1 | awk '{print $3}' | awk -F'/' '{print $1}')
 	if [ "${tmp_frspace}" -lt '307200' ]; then
 		echo "Warning, ${ZBREW_TMP} is low on free space, it is recommended to have at least 300 MB available"
@@ -212,140 +158,28 @@ prodprereq() {
 }
 
 
-fmids() {
-	zbrewlog "fmids" $*
-	sw=$1
-	smplist="${ZBREW_TMP}/smpfmid.$$.smplist"
-	smpout=`smp -i "${ZBREW_HLQ}${sw}G.GLOBAL.CSI" -l "${smplist}" <<zzz
-  SET BDY(GLOBAL).
-  LIST FUNCTIONS.
-zzz`
-	rc=$?
-	zbrewlog "fmids RC: ${rc}"
-	if [ $rc -eq 0 ]; then
-		fmids=`awk ' /= FUNCTION/ { print $1; }' ${smplist}`
-		uniq_fmids=`echo ${fmids} | tr ' ' '\n' | sort | uniq`
-		echo ${uniq_fmids}
-		
-	else
-	    	echo "smpfmid failed with rc:$rc" >&2
-		echo "${smpout}" >&2
-	fi
-	rm -f "${smplist}"
-	return $rc
-}
 
-fmidset() {
-	zbrewlog "fmidset" $*
-	sw=$1
-	shift
-	fmids=$*
-	fmidset="${sw}FS"
-
-	tmpCntlHFS="${ZBREW_TMP}/smpfmid.$$.smpcntl"
-	echo "  SET BDY(GLOBAL)." >>${tmpCntlHFS}
-	echo "  UCLIN." >>${tmpCntlHFS}
-	echo "  REP FMIDSET(${fmidset})" >>${tmpCntlHFS}
-	echo "  FMID(" >>${tmpCntlHFS}
-	for fmid in $fmids; do
-		echo "    ${fmid}" >>${tmpCntlHFS}
-	done
-	echo "  )." >>${tmpCntlHFS}
-	echo "  ENDUCL." >>${tmpCntlHFS}
-	smpout=`smp -i "${ZBREW_HLQ}${sw}G.GLOBAL.CSI" <${tmpCntlHFS}`
-	rc=$?
-	zbrewlog "fmidset RC: ${rc}"
-	rm ${tmpCntlHFS}
-	if [ $rc -gt 4 ] || [ $verbose -gt 0 ]; then
-		echo "fmidset ended with return code: $rc" >&2
-		echo "${smpout}" >&2
-	fi      
-	echo "${fmidset}"
-	return $rc
-}
-
-apply() {
-	
-	smpfunc=$(echo ${1} | tr '[:lower:]' '[:upper:]') 
-	zbrewlog "${smpfunc}" $*
-	check=$(echo ${2} | tr '[:lower:]' '[:upper:]') 
-	sw=$(echo ${3} | tr '[:lower:]' '[:upper:]')
-	shift 3
-	opts=$*
-	fmids=`fmids ${sw}`
-	if [ $? -gt 0 ]; then
-		return $?
-	fi
-	fmidset=`fmidset ${sw} ${fmids}`
-	if [ $? -gt 4 ]; then
-		return $?
-	fi
-
-        if [ ${verbose} -gt 0 ]; then
-                echo "Running ${smpfunc} ${check} ${sw} ${fmidset}" >&2
-        fi
-	smpappacc ${opts} ${smpfunc} ${check} ${sw} ${fmidset}
-	rc=$?
-	zbrewlog "${smpfunc} RC: ${rc}"
-	return $rc
-}
-
-
-prodalloc() {
-	zbrewlog "prodalloc" $*
-        sw=$1
-        shift 1
-        opts=$*
-        ussname=$(echo ${sw} | tr '[:upper:]' '[:lower:]')
-        prefix=`echo ${ussname} | awk '{print substr($0,0,3)}'`
-        if [ ${verbose} -gt 0 ]; then
-                echo "proddsalloc ${prefix} ${ussname}" >&2
-        fi
-        proddsalloc ${prefix} ${ussname} ${opts}
-        rc=$?
-	zbrewlog "prodalloc RC: ${rc}" 
-        return $rc
-}
-
-
-smpcrdddefs() {
-	zbrewlog "smpcrdddef" $*
-        sw=$1
-        shift 1
-        opts=$*
-	ussname=$(echo ${sw} | tr '[:upper:]' '[:lower:]')
-	prefix=`echo ${ussname} | awk '{print substr($0,0,3)}'`
-	if [ ${verbose} -gt 0 ]; then
-		echo "smpcrdddef ${prefix} ${ussname} ${opts}" >&2
-	fi
-	smpcrdddef ${prefix} ${ussname} ${opts}
-	rc=$?
-	zbrewlog "smpcrdddef RC: ${rc}"
-
-	return $rc
-}
 
 
 install() {
 	zbrewlog "install" $*
-	restart=$1
-	sw=$2
-	shift 2
-	opts=$*
-	
 	for zbrewfunc in ${install_verbs}; do
 		runfunc="${zbrewfunc}"
 		if [ "${runfunc}" = "smpapplycheck" ]; then
-			runfunc="apply apply CHECK"
+			opts="$opts -p"
+			runfunc="smpappacc"
 		fi
 		if [ "${runfunc}" = "smpapply" ]; then
-                        runfunc="apply apply NOCHECK"
+			opts="$opts -q"
+                        runfunc="smpappacc"
 		fi
                 if [ "${runfunc}" = "smpacceptcheck" ]; then
-                        runfunc="apply accept CHECK"
+			opts="$opts -r"
+                        runfunc="smpappacc"
                 fi
                 if [ "${runfunc}" = "smpaccept" ]; then
-                        runfunc="apply accept NOCHECK"
+			opts="$opts -s"
+                        runfunc="smpappacc"
                 fi
 
 		if [ "${restart}" != "NORESTART" ]; then
@@ -355,7 +189,7 @@ install() {
 				restart="NORESTART"
 			fi
 		fi
-		out=`${runfunc} ${sw} ${opts}`
+		out=`${runfunc} ${opts} ${sw}`
 		rc=$?
 		zbrewlog "${runfunc} RC: ${rc}"
 		if [ "$rc" -gt 0 ] || [ "$verbose" -gt 0 ]; then
@@ -393,11 +227,11 @@ configure() {
 	fi
 }
 
-install_verbs="prodprereq smpconfig receive smpcrdddefs prodalloc smpapplycheck smpapply smpacceptcheck smpaccept"
+install_verbs="prodprereq smpconfig receive smpcrdddef proddsalloc smpapplycheck smpapply smpacceptcheck smpaccept"
 debug=0
 verbose=0
 clean=0
-restart='NORESTART'
+restart="NORESTART"
 opts=""
 while getopts ":cvdr:" opt; do
   case ${opt} in
@@ -446,6 +280,7 @@ fi
 mydir=$(callerdir ${0})
 props="${mydir}/../properties/zbrewprops.json"
 zbrewpropse zbrew config "${props}"
+sw=$2
 ussname=$(echo ${2} | tr '[:upper:]' '[:lower:]');
 zosname=$(echo ${2} | tr '[:lower:]' '[:upper:]');
 
@@ -470,25 +305,24 @@ case ${verb} in
 		if [ ${verbose} -gt 0 ]; then
 			echo "Allocate SMP/E datasets for $2 " >&2
 		fi
-		smpconfig ${opts} ${zosname}
+		out=`smpconfig ${opts} ${sw}`
 		rc=$?
 		if [ $rc -gt 0 ]; then
 			echo "Unable to configure SMP/E datasets." >&2
+			echo "${out}" >&2
 			exit $rc
 		fi
 		;;
 	smpreceive )
-		NTS=`receive ${zosname}`; 
+		out=`receive ${opts} ${sw}`; 
 		rc=$? 
 		if [ $rc -gt 0 ]; then
+			echo "${out}"
 			exit $rc
-		fi
-		if [ ${clean} -gt 0 ]; then
-			rm -rf ${NTS}
 		fi
 		;;
 	prodprereq )
-		out=`prodprereq $2 ${opts}`
+		out=`prodprereq ${opts} ${sw}`
 		rc=$?
 		if [ $verbose -gt 0 ]; then
 			echo ${out}
@@ -498,16 +332,16 @@ case ${verb} in
 			exit $rc
 		fi
 		;;
-	smpcrdddefs )
-		out=`smpcrdddefs $2 ${opts}`
+	smpcrdddef )
+		out=`smpcrdddef ${opts} ${sw}`
 		rc=$?
 		if [ $rc -gt 0 ]; then
                         echo "${out}"
                         exit $rc
                 fi
                 ;;
-	prodalloc )
-		out=`prodalloc $2 ${opts}`
+	proddsalloc )
+		out=`proddsalloc ${opts} ${sw}`
 		rc=$?
 		if [ $rc -gt 0 ]; then
 			echo "${out}"
@@ -515,7 +349,8 @@ case ${verb} in
 		fi
 		;;
 	smpapplycheck )
-		out=`apply apply CHECK $2 ${opts}`
+		opts="${opts} -p"
+		out=`smpappacc ${opts} ${sw}`
 		rc=$?
 		if [ $rc -gt 0 ] || [ $verbose -gt 0 ]; then
                         echo "${out}"
@@ -523,7 +358,8 @@ case ${verb} in
                 fi
                 ;;
 	smpapply )
-		out=`apply apply NOCHECK $2 ${opts}`;
+		opts="${opts} -q"
+		out=`smpappacc ${opts} ${sw}`
 		rc=$? 
 		if [ $rc -gt 0 ] || [ $verbose -gt 0 ]; then
 			echo "${out}" 
@@ -531,7 +367,8 @@ case ${verb} in
 		fi
 		;;
         smpacceptcheck )
-                out=`apply accept CHECK $2 ${opts}`
+		opts="${opts} -r"
+                out=`smpappacc ${opts} ${sw}`
                 rc=$?
                 if [ $rc -gt 0 ] || [ $verbose -gt 0 ]; then
                         echo "${out}"
@@ -539,7 +376,8 @@ case ${verb} in
                 fi
                 ;;
         smpaccept )
-                out=`apply accept NOCHECK $2 ${opts}`;
+		opts="${opts} -s"
+                out=`smpappacc ${opts} ${sw}`;
                 rc=$?
                 if [ $rc -gt 0 ] || [ $verbose -gt 0 ]; then
                         echo "${out}"
@@ -547,8 +385,8 @@ case ${verb} in
                 fi
                 ;;
 	
-	install ) 
-		out=`install ${restart} $2 ${opts}`
+	install )
+		out=`install ${opts} ${sw}`
 		rc=$? 
 		if [ $rc -gt 0 ] || [ $verbose -gt 0 ]; then
 			echo "${out}" 


### PR DESCRIPTION
Standardized ways to call functions/modules .. such that most/all functions/modules are called using only ${opts} ${sw}.  Prior to this commit there was a mix of different methods and where ${opts} was not the first thing being passed which causes problems for external modules. 

Moved some code out of zbrew and into smpappacc (fmids and fmidset) 

Removed redundant code and streamlined ... to reduce complexity where multiple function calls were made for the same process (eg. smpreceive > receive() > receivelocal() > smpfromnts) 

Clean function additions/changes.